### PR TITLE
Change order of method calls in synopsis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ require 'xmpp4r/robot'
 
 robot = Jabber::Robot.new('someone@gmail.com', 'awesome password',
                           :auto_accept_subscription => true)
+                          
+p robot.start.roster
 
 robot.notify_presence do |from, status|
   # status could be one of :available, :away, :unavailable
@@ -45,8 +47,6 @@ robot.notify_message do |from, body|
 
   robot.subscribe(from) if body == 'subscribe' # demonstrate how we subscribe
 end
-
-p robot.start.roster
 
 rd, wr = IO.pipe
 Signal.trap('INT'){ wr.puts }


### PR DESCRIPTION
The given example in README.md didn't work for me.
After changing the order and call `robot.start` first, it worked.
This is because `robot.start` initializes a new `client` object.
`robot.notify_message` and `robot.notify_presence` both hook into the `client` object.